### PR TITLE
Fix for php 7.2

### DIFF
--- a/src/PHPThumb/GD.php
+++ b/src/PHPThumb/GD.php
@@ -56,7 +56,7 @@ class GD extends PHPThumb
      *
      * @var array
      */
-    protected $options;
+    protected $options = [];
 
     /**
      * The maximum width an image can be after resizing (in pixels)


### PR DESCRIPTION
Version 7.2 throws an warning when setOptions method is called
Warning:  sizeof(): Parameter must be an array or an object that implements Countable in /path/to/project/vendor/masterexploder/phpthumb/src/PHPThumb/GD.php on line <b>